### PR TITLE
Taking care of the possible null value that can be returned by mediaExtractor.getTrackFormat

### DIFF
--- a/domain/src/main/java/org/m4m/domain/MediaSource.java
+++ b/domain/src/main/java/org/m4m/domain/MediaSource.java
@@ -155,6 +155,7 @@ public class MediaSource implements IMediaSource {
     public Iterable<MediaFormat> getMediaFormats() {
         LinkedList<MediaFormat> result = new LinkedList<MediaFormat>();
         for (int i = 0; i < mediaExtractor.getTrackCount(); i++) {
+            if (mediaExtractor.getTrackFormat(i) == null) continue;
             result.add(mediaExtractor.getTrackFormat(i));
         }
         return result;
@@ -228,7 +229,8 @@ public class MediaSource implements IMediaSource {
         long maxDuration = 0;
         int i = 0;
         for (MediaFormat ignored : getMediaFormats()) {
-            if (mediaExtractor.getTrackFormat(i).getDuration() > maxDuration) {
+            if (mediaExtractor.getTrackFormat(i) != null
+            && (mediaExtractor.getTrackFormat(i).getDuration() > maxDuration)) {
                 maxDuration = mediaExtractor.getTrackFormat(i).getDuration();
             }
             i++;
@@ -268,8 +270,12 @@ public class MediaSource implements IMediaSource {
     }
 
     private boolean isVideoTrack(int trackId) {
-        String mimeType = mediaExtractor.getTrackFormat(trackId).getMimeType();
-        return mimeType.startsWith("video");
+        if (mediaExtractor.getTrackFormat(trackId) != null) {
+            String mimeType = mediaExtractor.getTrackFormat(trackId).getMimeType();
+            return mimeType.startsWith("video");
+        } else {
+            return false;
+        }
     }
 
     @Override


### PR DESCRIPTION
Hi there 👋 .
We have this issue [here](https://github.com/wordpress-mobile/WordPress-Android/issues/13692) where we get the following:

```
Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String org.m4m.domain.MediaFormat.getMimeType()' on a null object reference
        at org.m4m.domain.MediaSource.getMediaFormatByType(MediaSource.java:166)
        at org.m4m.MediaFile.getVideoFormat(MediaFile.java:112)
        at org.m4m.MediaFileInfo.prepareMediaFile(MediaFileInfo.java:135)
        at org.m4m.MediaFileInfo.setUri(MediaFileInfo.java:88)
```

Looking into it, we are getting that Null Pointer Exception in some cases/conditions:
- specific videos, 
- specific devices like Pixel 4a or some Samsung devices and also Pixel 3 Emulator; 
- various API levels but it seems it can depend from the device custom flavour of Android; for example matching other conditions, no problems in a OnePlus 7T.

If I'm not wrong, the issue seems related to the fact that the `mediaExtractor.getTrackFormat` can return a null value:

```
@Override
    public MediaFormat getTrackFormat(int index) {
        if (mediaExtractor.getTrackFormat(index).getString(android.media.MediaFormat.KEY_MIME).contains("video")) {
            return new VideoFormatAndroid(mediaExtractor.getTrackFormat(index));
        } else if (mediaExtractor.getTrackFormat(index).getString(android.media.MediaFormat.KEY_MIME).contains("audio")) {
            return new AudioFormatAndroid(mediaExtractor.getTrackFormat(index));
        }
        return null;
    }
```

and in one case I could verify we had 3 tracks rescued by `mediaExtractor.getTrackFormat` with values 

- mediaExtractor.getTrackFormat(0).getString(android.media.MediaFormat.KEY_MIME) -> application/meta
- mediaExtractor.getTrackFormat(1).getString(android.media.MediaFormat.KEY_MIME) -> audio/mp4a-latm
- mediaExtractor.getTrackFormat(2).getString(android.media.MediaFormat.KEY_MIME) -> video/avc

the first raw is a possible scenario when we can get the crash returning a null value.

Linking to the lib code of this PR I could verify that all worked ok for me. Also checked the samples in the lib and AFAIU seems working ok.

I see the lib is already checking that possible null return value in all the other places in `MediaSource.java` so the modification should just add that check all over the places where it's used.
I was wondering if you could review this PR and confirm if it can be fine to merge (I'm not familiar with your code base so happy to get your feedbacks).

Thanks for your attention and time 🙇‍♂️.
